### PR TITLE
Add guard:cleanup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,9 @@ php artisan guard:install
 # Pull blacklist from master and rebuild local Redis cache
 php artisan guard:sync
 
-# Delete expired temporary blocks and rebuild Redis cache
+# Delete expired temporary blocks and rebuild the Redis cache
 # Runs automatically every day — set GUARD_CLEANUP_ENABLED=false to manage manually
+# Permanent blocks (no expiry) are never touched
 php artisan guard:cleanup
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Every incoming request is checked against a **Redis Hash** before any middleware
 - PHP 8.2+
 - Laravel 10+
 - Redis
-- [ahmedmerza/logscope](https://github.com/AhmedMerza/laravel-logscope) >= 1.5.1
+- [ahmedmerza/logscope](https://github.com/AhmedMerza/laravel-logscope) >= 1.5.2
 
 ---
 
@@ -98,6 +98,12 @@ GUARD_AUTO_BLOCK_DURATION=60
 # Webhook notification on every block (optional — useful for n8n, Slack, WhatsApp)
 GUARD_WEBHOOK_URL=
 GUARD_NOTIFICATION_QUEUE=default
+
+# Dedicated log channel for Guard events (sync failures, auto-block skips, etc.)
+GUARD_LOG_CHANNEL=stack
+
+# Automatic cleanup of expired temporary blocks (runs daily)
+GUARD_CLEANUP_ENABLED=true
 ```
 
 ### Block Response
@@ -218,6 +224,10 @@ php artisan guard:install
 
 # Pull blacklist from master and rebuild local Redis cache
 php artisan guard:sync
+
+# Delete expired temporary blocks and rebuild Redis cache
+# Runs automatically every day — set GUARD_CLEANUP_ENABLED=false to manage manually
+php artisan guard:cleanup
 ```
 
 ---

--- a/config/logscope-guard.php
+++ b/config/logscope-guard.php
@@ -150,4 +150,22 @@ return [
 
     'log_channel' => env('GUARD_LOG_CHANNEL', 'stack'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Cleanup
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, Guard automatically runs 'guard:cleanup' daily to remove
+    | expired temporary blocks from the database. Only rows with a past
+    | expires_at are deleted — permanent blocks (expires_at = null) are
+    | never touched.
+    |
+    | Set to false if you prefer to schedule or run cleanup manually.
+    |
+    */
+
+    'cleanup' => [
+        'enabled' => env('GUARD_CLEANUP_ENABLED', true),
+    ],
+
 ];

--- a/src/Console/Commands/CleanupCommand.php
+++ b/src/Console/Commands/CleanupCommand.php
@@ -27,9 +27,10 @@ class CleanupCommand extends Command
 
         if ($deleted > 0) {
             $this->cache->rebuild();
+            $this->info("Removed {$deleted} expired block(s). Redis cache rebuilt.");
+        } else {
+            $this->info('Nothing to clean up — no expired blocks found.');
         }
-
-        $this->info("Removed {$deleted} expired block(s). Redis cache rebuilt.");
 
         return self::SUCCESS;
     }

--- a/src/Console/Commands/CleanupCommand.php
+++ b/src/Console/Commands/CleanupCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LogScopeGuard\Console\Commands;
+
+use Illuminate\Console\Command;
+use LogScopeGuard\Models\BlacklistedIp;
+use LogScopeGuard\Services\BlacklistCache;
+
+class CleanupCommand extends Command
+{
+    protected $signature = 'guard:cleanup';
+
+    protected $description = 'Delete expired temporary blocks from the database and rebuild the Redis cache';
+
+    public function __construct(private readonly BlacklistCache $cache)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $deleted = BlacklistedIp::whereNotNull('expires_at')
+            ->where('expires_at', '<', now())
+            ->delete();
+
+        if ($deleted > 0) {
+            $this->cache->rebuild();
+        }
+
+        $this->info("Removed {$deleted} expired block(s). Redis cache rebuilt.");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Http/Middleware/BlockedIpMiddleware.php
+++ b/src/Http/Middleware/BlockedIpMiddleware.php
@@ -39,7 +39,7 @@ class BlockedIpMiddleware
                 return redirect($blockConfig['redirect']);
             }
 
-            abort($blockConfig['status'], $blockConfig['message']);
+            return response($blockConfig['message'], $blockConfig['status']);
         }
 
         return $next($request);

--- a/src/LogScopeGuardServiceProvider.php
+++ b/src/LogScopeGuardServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Schedule;
+use LogScopeGuard\Console\Commands\CleanupCommand;
 use LogScopeGuard\Console\Commands\InstallCommand;
 use LogScopeGuard\Console\Commands\SyncCommand;
 use LogScopeGuard\Events\IpBlocked;
@@ -30,7 +31,7 @@ class LogScopeGuardServiceProvider extends PackageServiceProvider
             ->hasMigration('create_blacklisted_ips_table')
             ->runsMigrations()
             ->hasViews()
-            ->hasCommands([InstallCommand::class, SyncCommand::class]);
+            ->hasCommands([InstallCommand::class, SyncCommand::class, CleanupCommand::class]);
     }
 
     public function registeringPackage(): void
@@ -62,6 +63,13 @@ class LogScopeGuardServiceProvider extends PackageServiceProvider
             Schedule::call(fn () => $this->app->make(AutoBlockService::class)->run())
                 ->everyMinute()
                 ->name('logscope-guard:auto-block')
+                ->withoutOverlapping();
+        }
+
+        if (config('logscope-guard.cleanup.enabled', true)) {
+            Schedule::command('guard:cleanup')
+                ->daily()
+                ->name('logscope-guard:cleanup')
                 ->withoutOverlapping();
         }
     }

--- a/tests/Feature/BlockApiTest.php
+++ b/tests/Feature/BlockApiTest.php
@@ -76,6 +76,11 @@ it('returns the correct status for a blocked IP', function () {
         'expires_at' => null,
     ]);
 
+    // status() checks Redis as truth — simulate a permanent block (empty string)
+    Redis::shouldReceive('hget')
+        ->with('logscope_guard:blacklist', '10.0.0.3')
+        ->andReturn('');
+
     $response = $this->getJson('/logscope/guard/api/status/10.0.0.3');
 
     $response->assertStatus(200)

--- a/tests/Feature/CleanupCommandTest.php
+++ b/tests/Feature/CleanupCommandTest.php
@@ -53,13 +53,16 @@ it('never deletes permanent blocks (expires_at is null)', function () {
 
     $this->artisan('guard:cleanup')
         ->assertSuccessful()
-        ->expectsOutputToContain('Removed 0 expired block');
+        ->expectsOutputToContain('Nothing to clean up');
 
     $this->assertDatabaseHas('blacklisted_ips', ['ip' => '3.3.3.3']);
 });
 
 it('only rebuilds the cache when records were deleted', function () {
-    // No expired blocks — cache should not be rebuilt
+    // No expired blocks exist, so rebuild() (which calls del) must not be called.
+    // warmOnBoot() won't trigger del here because Redis::exists() is mocked to
+    // return 1 (key exists), so it short-circuits before calling rebuild().
+    Redis::shouldReceive('exists')->andReturn(1)->byDefault();
     Redis::shouldNotReceive('del');
 
     BlacklistedIp::create([
@@ -72,10 +75,10 @@ it('only rebuilds the cache when records were deleted', function () {
     $this->artisan('guard:cleanup')->assertSuccessful();
 });
 
-it('reports zero when nothing to clean up', function () {
+it('reports nothing to clean up when the table is empty', function () {
     $this->artisan('guard:cleanup')
         ->assertSuccessful()
-        ->expectsOutputToContain('Removed 0 expired block');
+        ->expectsOutputToContain('Nothing to clean up');
 });
 
 it('can still be run manually even when GUARD_CLEANUP_ENABLED is false', function () {

--- a/tests/Feature/CleanupCommandTest.php
+++ b/tests/Feature/CleanupCommandTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Redis;
+use LogScopeGuard\Enums\BlockSource;
+use LogScopeGuard\Models\BlacklistedIp;
+
+beforeEach(function () {
+    Redis::shouldReceive('connection')->andReturnSelf()->byDefault();
+    Redis::shouldReceive('del')->andReturn(1)->byDefault();
+    Redis::shouldReceive('hmset')->andReturn(true)->byDefault();
+    Redis::shouldReceive('expire')->andReturn(true)->byDefault();
+    Redis::shouldReceive('exists')->andReturn(0)->byDefault();
+    Redis::shouldReceive('hget')->andReturn(null)->byDefault();
+});
+
+it('deletes expired temporary blocks', function () {
+    BlacklistedIp::create([
+        'ip'         => '1.2.3.4',
+        'source'     => BlockSource::Auto,
+        'source_env' => 'testing',
+        'expires_at' => now()->subHour(),
+    ]);
+
+    $this->artisan('guard:cleanup')
+        ->assertSuccessful()
+        ->expectsOutputToContain('Removed 1 expired block');
+
+    $this->assertDatabaseMissing('blacklisted_ips', ['ip' => '1.2.3.4']);
+});
+
+it('does not delete blocks that have not expired yet', function () {
+    BlacklistedIp::create([
+        'ip'         => '2.2.2.2',
+        'source'     => BlockSource::Auto,
+        'source_env' => 'testing',
+        'expires_at' => now()->addHour(),
+    ]);
+
+    $this->artisan('guard:cleanup')->assertSuccessful();
+
+    $this->assertDatabaseHas('blacklisted_ips', ['ip' => '2.2.2.2']);
+});
+
+it('never deletes permanent blocks (expires_at is null)', function () {
+    BlacklistedIp::create([
+        'ip'         => '3.3.3.3',
+        'source'     => BlockSource::Manual,
+        'source_env' => 'testing',
+        'expires_at' => null,
+    ]);
+
+    $this->artisan('guard:cleanup')
+        ->assertSuccessful()
+        ->expectsOutputToContain('Removed 0 expired block');
+
+    $this->assertDatabaseHas('blacklisted_ips', ['ip' => '3.3.3.3']);
+});
+
+it('only rebuilds the cache when records were deleted', function () {
+    // No expired blocks — cache should not be rebuilt
+    Redis::shouldNotReceive('del');
+
+    BlacklistedIp::create([
+        'ip'         => '4.4.4.4',
+        'source'     => BlockSource::Manual,
+        'source_env' => 'testing',
+        'expires_at' => null,
+    ]);
+
+    $this->artisan('guard:cleanup')->assertSuccessful();
+});
+
+it('reports zero when nothing to clean up', function () {
+    $this->artisan('guard:cleanup')
+        ->assertSuccessful()
+        ->expectsOutputToContain('Removed 0 expired block');
+});
+
+it('can still be run manually even when GUARD_CLEANUP_ENABLED is false', function () {
+    config()->set('logscope-guard.cleanup.enabled', false);
+
+    BlacklistedIp::create([
+        'ip'         => '5.5.5.5',
+        'source'     => BlockSource::Auto,
+        'source_env' => 'testing',
+        'expires_at' => now()->subHour(),
+    ]);
+
+    // The config flag only stops the scheduler — the command itself still works
+    $this->artisan('guard:cleanup')
+        ->assertSuccessful()
+        ->expectsOutputToContain('Removed 1 expired block');
+
+    $this->assertDatabaseMissing('blacklisted_ips', ['ip' => '5.5.5.5']);
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,6 +26,8 @@ class TestCase extends Orchestra
 
     public function getEnvironmentSetUp($app): void
     {
+        config()->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
+
         config()->set('database.default', 'testing');
         config()->set('database.connections.testing', [
             'driver'   => 'sqlite',
@@ -37,5 +39,19 @@ class TestCase extends Orchestra
         foreach (\Illuminate\Support\Facades\File::allFiles(__DIR__.'/../database/migrations') as $migration) {
             (include $migration->getRealPath())->up();
         }
+
+        // Create a minimal log_entries table so AutoBlockService tests can run
+        // without requiring the full LogScope package to be installed.
+        \Illuminate\Support\Facades\DB::statement('
+            CREATE TABLE IF NOT EXISTS log_entries (
+                id VARCHAR(26) PRIMARY KEY,
+                level VARCHAR(20) NOT NULL,
+                message TEXT NOT NULL,
+                ip_address VARCHAR(50),
+                occurred_at DATETIME NOT NULL,
+                created_at DATETIME,
+                updated_at DATETIME
+            )
+        ');
     }
 }


### PR DESCRIPTION
## Summary

- Adds `guard:cleanup` artisan command that deletes expired temporary blocks from the database and rebuilds the Redis cache
- Scheduled daily automatically — only rows with a past `expires_at` are deleted, permanent blocks (`expires_at = null`) are never touched
- Opt-out via `GUARD_CLEANUP_ENABLED=false` in `.env` — the schedule is skipped but the command can still be run manually
- Adds `GUARD_LOG_CHANNEL` config key so all Guard log entries can be routed to a dedicated channel

## Test plan

- [ ] `guard:cleanup` deletes expired blocks and reports the count
- [ ] Permanent blocks (null `expires_at`) are never deleted
- [ ] Active temporary blocks (future `expires_at`) are not deleted
- [ ] Redis cache is only rebuilt when at least one record was deleted
- [ ] `GUARD_CLEANUP_ENABLED=false` skips the scheduler but command still runs manually