### PR TITLE
Auto-block warn-only mode (block | warn | disabled)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `laravel-watchtower` will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Auto-block warn-only mode** — new `watchtower.auto_block.mode` config (`block` | `warn` | `disabled`, default `block`) plus optional per-rule `mode` override. In `warn` mode, the engine matches rules and emits a structured `would_have_blocked: true` log entry on the configured `log_channel`, but does NOT actually block — operators can validate a rule against real traffic before flipping it to `block`. `disabled` skips a rule entirely (per-rule kill switch). New env var: `WATCHTOWER_AUTO_BLOCK_MODE`. Backward-compatible: configs that don't set a mode get the prior `block` behaviour.
+
 ### Changed (BREAKING — single rename release)
 
 - **Package renamed: `ahmedmerza/logscope-guard` → `ahmedmerza/laravel-watchtower`.** Reflects the strategic pivot away from "LogScope addon" toward "standalone Laravel app-edge blocker, with optional LogScope integration."

--- a/config/watchtower.php
+++ b/config/watchtower.php
@@ -97,24 +97,47 @@ return [
     | Automatically block IPs that match log-based rules. Disabled by default.
     | Rules are evaluated every minute via the scheduler.
     |
+    | Mode (global default — overrideable per rule):
+    |   'block'    - actually block matching IPs (production behaviour).
+    |   'warn'     - match the rule and emit a structured `would_have_blocked`
+    |                log entry on the configured `log_channel`, but do NOT
+    |                block. Use this when first turning auto-block on in a
+    |                new environment: tail your logs (or query LogScope) for
+    |                `would_have_blocked: true` to see what a rule WOULD
+    |                catch before letting it lock anyone out. Once you trust
+    |                the rule, flip to 'block'.
+    |   'disabled' - skip the rule entirely. Useful as a per-rule kill switch
+    |                without removing the rule definition.
+    |
     | Rule shape:
     |   level            - log level to match (e.g. 'error', 'warning'). Null = any.
     |   message_contains - substring match on log message. Null = any.
     |   count            - number of matching logs within the window to trigger a block.
     |   window_minutes   - look-back window for counting logs.
+    |   mode             - (optional) override the global mode for this rule only.
     |
     */
 
     'auto_block' => [
         'enabled'                => env('WATCHTOWER_AUTO_BLOCK_ENABLED', env('GUARD_AUTO_BLOCK_ENABLED', false)),
+        'mode'                   => env('WATCHTOWER_AUTO_BLOCK_MODE', 'block'),
         'block_duration_minutes' => env('WATCHTOWER_AUTO_BLOCK_DURATION', env('GUARD_AUTO_BLOCK_DURATION', 60)),
         'rules'                  => [
-            // Example:
+            // Example — production rule:
             // [
             //     'level'            => 'error',
             //     'message_contains' => null,
             //     'count'            => 50,
             //     'window_minutes'   => 5,
+            // ],
+            //
+            // Example — same rule running in warn mode while you tune it:
+            // [
+            //     'level'            => 'error',
+            //     'message_contains' => null,
+            //     'count'            => 50,
+            //     'window_minutes'   => 5,
+            //     'mode'             => 'warn',
             // ],
         ],
     ],

--- a/src/Services/AutoBlockService.php
+++ b/src/Services/AutoBlockService.php
@@ -10,6 +10,11 @@ use Watchtower\Enums\BlockSource;
 
 class AutoBlockService
 {
+    /**
+     * Valid auto-block modes. Anything else falls back to 'block'.
+     */
+    private const VALID_MODES = ['block', 'warn', 'disabled'];
+
     public function __construct(private readonly BlacklistService $blacklist) {}
 
     public function run(): void
@@ -20,13 +25,41 @@ class AutoBlockService
 
         $rules = config('watchtower.auto_block.rules', []);
         $durationMinutes = (int) config('watchtower.auto_block.block_duration_minutes', 60);
+        $globalMode = $this->normaliseMode(config('watchtower.auto_block.mode', 'block'));
 
-        foreach ($rules as $rule) {
-            $this->applyRule($rule, $durationMinutes);
+        foreach ($rules as $index => $rule) {
+            $mode = $this->resolveRuleMode($rule, $globalMode);
+
+            if ($mode === 'disabled') {
+                continue;
+            }
+
+            $this->applyRule($rule, (int) $index, $mode, $durationMinutes);
         }
     }
 
-    private function applyRule(array $rule, int $durationMinutes): void
+    /**
+     * Per-rule `mode` overrides the global mode. Both fall back to 'block'
+     * when missing or invalid — preserves the pre-warn-mode behaviour for
+     * configs that don't specify a mode at all.
+     */
+    private function resolveRuleMode(array $rule, string $globalMode): string
+    {
+        if (isset($rule['mode']) && in_array($rule['mode'], self::VALID_MODES, true)) {
+            return $rule['mode'];
+        }
+
+        return $globalMode;
+    }
+
+    private function normaliseMode(mixed $mode): string
+    {
+        return is_string($mode) && in_array($mode, self::VALID_MODES, true)
+            ? $mode
+            : 'block';
+    }
+
+    private function applyRule(array $rule, int $ruleIndex, string $mode, int $durationMinutes): void
     {
         $windowMinutes   = (int) ($rule['window_minutes'] ?? 5);
         $threshold       = (int) ($rule['count'] ?? 10);
@@ -66,6 +99,13 @@ class AutoBlockService
                 continue;
             }
 
+            if ($mode === 'warn') {
+                $this->logWouldHaveBlocked($ip, $ruleIndex, $rule, $threshold, $windowMinutes, $reason);
+
+                continue;
+            }
+
+            // mode === 'block'
             try {
                 $this->blacklist->block($ip, [
                     'reason'     => $reason,
@@ -78,5 +118,33 @@ class AutoBlockService
                     ->debug('Watchtower: auto-block skipped for whitelisted IP', ['ip' => $ip]);
             }
         }
+    }
+
+    /**
+     * Emit a structured "would have blocked" log entry. The
+     * `would_have_blocked: true` key is the canonical filter — operators
+     * can grep for it (or query LogScope) to see exactly which IPs a rule
+     * would have caught before they flip the mode to 'block'.
+     */
+    private function logWouldHaveBlocked(
+        string $ip,
+        int $ruleIndex,
+        array $rule,
+        int $threshold,
+        int $windowMinutes,
+        string $reason,
+    ): void {
+        Log::channel(config('watchtower.log_channel', 'stack'))->warning(
+            'Watchtower: would-have-blocked (auto-block in warn mode)',
+            [
+                'would_have_blocked' => true,
+                'ip'                 => $ip,
+                'rule_index'         => $ruleIndex,
+                'rule'               => $rule,
+                'threshold'          => $threshold,
+                'window_minutes'     => $windowMinutes,
+                'reason'             => $reason,
+            ],
+        );
     }
 }

--- a/tests/Unit/AutoBlockServiceTest.php
+++ b/tests/Unit/AutoBlockServiceTest.php
@@ -381,9 +381,18 @@ it('disabled mode skips the rule entirely (no block, no warn log)', function () 
         'updated_at'  => now(),
     ]);
 
-    // No log channel calls expected — Log::shouldNotReceive('channel') would
-    // be too strict (other code paths may resolve channels), so we just
-    // assert no blocks, no warn entries (the latter via DB absence).
+    // Pin the contract: disabled mode must not emit ANY warn-level log entry.
+    // DB-absence alone wouldn't catch a regression where a refactored
+    // disabled-mode path still ran applyRule() and emitted warns. Allow other
+    // log methods so unrelated code paths (debug, etc.) don't false-positive
+    // this assertion if anything else happens to resolve a channel.
+    $logChannel = \Mockery::mock();
+    $logChannel->shouldNotReceive('warning');
+    $logChannel->shouldReceive('debug')->zeroOrMoreTimes();
+    $logChannel->shouldReceive('info')->zeroOrMoreTimes();
+    $logChannel->shouldReceive('error')->zeroOrMoreTimes();
+    \Illuminate\Support\Facades\Log::shouldReceive('channel')->andReturn($logChannel);
+
     $this->service->run();
 
     $this->assertDatabaseMissing('blacklisted_ips', ['ip' => '15.15.15.15']);

--- a/tests/Unit/AutoBlockServiceTest.php
+++ b/tests/Unit/AutoBlockServiceTest.php
@@ -237,3 +237,178 @@ it('ignores log entries outside the time window', function () {
 
     $this->assertDatabaseMissing('blacklisted_ips', ['ip' => '4.4.4.4']);
 });
+
+/*
+ * Mode tests — per-rule `mode` overrides global `watchtower.auto_block.mode`.
+ * Modes: 'block' (default), 'warn' (log but don't block), 'disabled' (skip).
+ */
+
+it('warn mode logs a would-have-blocked entry and does NOT block', function () {
+    config()->set('watchtower.auto_block.mode', 'warn');
+    config()->set('watchtower.auto_block.rules', [[
+        'level'            => 'error',
+        'message_contains' => null,
+        'count'            => 2,
+        'window_minutes'   => 5,
+    ]]);
+
+    foreach (range(1, 2) as $i) {
+        \Illuminate\Support\Facades\DB::table('log_entries')->insert([
+            'id'          => \Illuminate\Support\Str::ulid(),
+            'level'       => 'error',
+            'message'     => 'Boom',
+            'ip_address'  => '11.11.11.11',
+            'occurred_at' => now(),
+            'created_at'  => now(),
+            'updated_at'  => now(),
+        ]);
+    }
+
+    $logChannel = \Mockery::mock();
+    $logChannel->shouldReceive('warning')
+        ->once()
+        ->withArgs(function (string $message, array $context): bool {
+            return $message === 'Watchtower: would-have-blocked (auto-block in warn mode)'
+                && $context['would_have_blocked'] === true
+                && $context['ip'] === '11.11.11.11'
+                && $context['threshold'] === 2
+                && $context['window_minutes'] === 5
+                && is_int($context['rule_index']);
+        });
+    \Illuminate\Support\Facades\Log::shouldReceive('channel')->andReturn($logChannel);
+
+    $this->service->run();
+
+    $this->assertDatabaseMissing('blacklisted_ips', ['ip' => '11.11.11.11']);
+});
+
+it('block mode (default) still blocks when no mode is configured anywhere', function () {
+    // No mode key set anywhere — should default to 'block'
+    config()->offsetUnset('watchtower.auto_block.mode');
+    config()->set('watchtower.auto_block.rules', [[
+        'level'            => 'error',
+        'message_contains' => null,
+        'count'            => 1,
+        'window_minutes'   => 5,
+    ]]);
+
+    \Illuminate\Support\Facades\DB::table('log_entries')->insert([
+        'id'          => \Illuminate\Support\Str::ulid(),
+        'level'       => 'error',
+        'message'     => 'Boom',
+        'ip_address'  => '12.12.12.12',
+        'occurred_at' => now(),
+        'created_at'  => now(),
+        'updated_at'  => now(),
+    ]);
+
+    $this->service->run();
+
+    $this->assertDatabaseHas('blacklisted_ips', ['ip' => '12.12.12.12', 'source' => 'auto']);
+});
+
+it('per-rule mode overrides global mode (rule=block wins over global=warn)', function () {
+    config()->set('watchtower.auto_block.mode', 'warn');
+    config()->set('watchtower.auto_block.rules', [[
+        'level'            => 'error',
+        'message_contains' => null,
+        'count'            => 1,
+        'window_minutes'   => 5,
+        'mode'             => 'block', // per-rule override
+    ]]);
+
+    \Illuminate\Support\Facades\DB::table('log_entries')->insert([
+        'id'          => \Illuminate\Support\Str::ulid(),
+        'level'       => 'error',
+        'message'     => 'Boom',
+        'ip_address'  => '13.13.13.13',
+        'occurred_at' => now(),
+        'created_at'  => now(),
+        'updated_at'  => now(),
+    ]);
+
+    $this->service->run();
+
+    $this->assertDatabaseHas('blacklisted_ips', ['ip' => '13.13.13.13', 'source' => 'auto']);
+});
+
+it('per-rule mode overrides global mode (rule=warn wins over global=block)', function () {
+    config()->set('watchtower.auto_block.mode', 'block');
+    config()->set('watchtower.auto_block.rules', [[
+        'level'            => 'error',
+        'message_contains' => null,
+        'count'            => 1,
+        'window_minutes'   => 5,
+        'mode'             => 'warn', // per-rule override
+    ]]);
+
+    \Illuminate\Support\Facades\DB::table('log_entries')->insert([
+        'id'          => \Illuminate\Support\Str::ulid(),
+        'level'       => 'error',
+        'message'     => 'Boom',
+        'ip_address'  => '14.14.14.14',
+        'occurred_at' => now(),
+        'created_at'  => now(),
+        'updated_at'  => now(),
+    ]);
+
+    // Mock the log channel so we don't need real logging infra
+    $logChannel = \Mockery::mock();
+    $logChannel->shouldReceive('warning')->once();
+    \Illuminate\Support\Facades\Log::shouldReceive('channel')->andReturn($logChannel);
+
+    $this->service->run();
+
+    $this->assertDatabaseMissing('blacklisted_ips', ['ip' => '14.14.14.14']);
+});
+
+it('disabled mode skips the rule entirely (no block, no warn log)', function () {
+    config()->set('watchtower.auto_block.rules', [[
+        'level'            => 'error',
+        'message_contains' => null,
+        'count'            => 1,
+        'window_minutes'   => 5,
+        'mode'             => 'disabled',
+    ]]);
+
+    \Illuminate\Support\Facades\DB::table('log_entries')->insert([
+        'id'          => \Illuminate\Support\Str::ulid(),
+        'level'       => 'error',
+        'message'     => 'Boom',
+        'ip_address'  => '15.15.15.15',
+        'occurred_at' => now(),
+        'created_at'  => now(),
+        'updated_at'  => now(),
+    ]);
+
+    // No log channel calls expected — Log::shouldNotReceive('channel') would
+    // be too strict (other code paths may resolve channels), so we just
+    // assert no blocks, no warn entries (the latter via DB absence).
+    $this->service->run();
+
+    $this->assertDatabaseMissing('blacklisted_ips', ['ip' => '15.15.15.15']);
+});
+
+it('invalid global mode value falls back to block', function () {
+    config()->set('watchtower.auto_block.mode', 'this-is-not-a-mode');
+    config()->set('watchtower.auto_block.rules', [[
+        'level'            => 'error',
+        'message_contains' => null,
+        'count'            => 1,
+        'window_minutes'   => 5,
+    ]]);
+
+    \Illuminate\Support\Facades\DB::table('log_entries')->insert([
+        'id'          => \Illuminate\Support\Str::ulid(),
+        'level'       => 'error',
+        'message'     => 'Boom',
+        'ip_address'  => '16.16.16.16',
+        'occurred_at' => now(),
+        'created_at'  => now(),
+        'updated_at'  => now(),
+    ]);
+
+    $this->service->run();
+
+    $this->assertDatabaseHas('blacklisted_ips', ['ip' => '16.16.16.16', 'source' => 'auto']);
+});


### PR DESCRIPTION
## Summary

Adds a **warn-only mode** to the auto-block engine so operators can validate rules against real traffic before letting them block anyone.

Three modes, with per-rule override of the global default:

| Mode | Behaviour |
|---|---|
| `block` | Default. Actually blocks matching IPs (current behaviour). |
| `warn` | Matches the rule, emits a structured `would_have_blocked: true` log entry on `watchtower.log_channel`, **does not block**. |
| `disabled` | Skips the rule entirely. Per-rule kill switch without removing the definition. |

## Why

Auto-block from log patterns is high-value but high-risk: a wrong threshold or a too-broad `message_contains` filter can lock out real customers. Without warn mode, the only ways to validate a rule are (a) manual log analysis to predict what it'd catch, or (b) turning it on and praying. Now the workflow is:

1. Add the rule with `mode: 'warn'`
2. Wait a week, watch the log channel for `would_have_blocked: true` entries
3. Adjust threshold / filter if false positives appear
4. Flip to `mode: 'block'` (or remove the per-rule mode and rely on the global default) once you trust it

## API

**Global default** (env-driven):

```env
WATCHTOWER_AUTO_BLOCK_MODE=warn
```

```php
// config/watchtower.php
'auto_block' => [
    'enabled' => true,
    'mode'    => env('WATCHTOWER_AUTO_BLOCK_MODE', 'block'),
    // ...
],
```

**Per-rule override:**

```php
'rules' => [
    [
        'level'            => 'error',
        'count'            => 50,
        'window_minutes'   => 5,
        'mode'             => 'warn',  // override global, run this rule in warn
    ],
    [
        'level'            => 'critical',
        'count'            => 5,
        'window_minutes'   => 5,
        // no mode key → uses global default
    ],
],
```

## Resolution priority

1. Per-rule `mode` (if set and valid)
2. Global `watchtower.auto_block.mode` (if set and valid)
3. Default: `block`

Invalid values (typos, etc.) fall back to `block` rather than silently disabling auto-block. Better to over-block in a misconfiguration than under-protect.

## Warn log structure

```json
{
    "would_have_blocked": true,
    "ip": "1.2.3.4",
    "rule_index": 0,
    "rule": { "level": "error", "count": 50, "window_minutes": 5, "mode": "warn" },
    "threshold": 50,
    "window_minutes": 5,
    "reason": "Auto-blocked: level=error exceeded 50 hits in 5 min"
}
```

`would_have_blocked: true` is the canonical filter — grep for it, or query LogScope for `context.would_have_blocked = true`.

## Backward compatibility

Configs that don't set any `mode` key get the prior `block` behaviour unchanged. No migration needed for existing users.

## Test plan

- [x] `composer test` — 62 passed (was 56, +6 new tests covering all three modes + override semantics + invalid-mode fallback)
- [x] All pre-existing AutoBlockServiceTest tests still pass
- [ ] Reviewer: configure a rule with `mode: 'warn'` in a real app, generate matching log entries, confirm `would_have_blocked: true` appears in the configured log channel and the IP is NOT in `blacklisted_ips`
- [ ] Reviewer: configure a rule with `mode: 'disabled'`, generate matching entries, confirm neither block nor warn fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)